### PR TITLE
20 añadir un comprobador ortográfico de la memoria

### DIFF
--- a/.github/workflows/words-allowlist.txt
+++ b/.github/workflows/words-allowlist.txt
@@ -1,0 +1,9 @@
+Triage 
+Issues
+issues 
+issue
+Triage 
+triage 
+commits 
+Testing
+git


### PR DESCRIPTION
El programa estaba instalado con anterioridad en local pero faltaban los comandos en el Makefile y el archivo de palabras que salta la excepción