### PR TITLE
Añadir comandos a Makefile para ejecutar el corrector ortográfico.

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -1,5 +1,10 @@
 DOC := proyecto.tex
 
+ignored_envs := otherlanguage,displaymath
+ignored_rules := sh:seclen,sh:stacked
+ignored_macros := tableofcontents,listoffigures,listoftables,begin,centeroffset,oddsidemargin,evensidemargin,centering,bfseries,end,cleardoublepage,setlength,texttt
+dict_es := ../.github/workflows/words-allowlist.txt
+
 all: doc
 
 doc: $(DOC:.tex=.pdf)
@@ -9,5 +14,18 @@ all: proyecto.pdf
 %.pdf: %.tex
 	pdflatex $< && bibtex $* && pdflatex $< && pdflatex $<
 
+clean:
+	rm -f *.log *.toc *.out *.bbl *.lof *.lot *.blg *.aux *.synctex.gz
 
+check: es-check en-check
+
+es-check:
+	textidote --check es --ignore $(ignored_rules) --remove $(ignored_envs) \
+	--remove-macros $(ignored_macros) --dict $(dict_es) --output html \
+	proyecto.tex > report_es.html
+
+en-check:
+	textidote --check en --read-all --ignore $(ignored_rules) \
+	--remove-macros $(ignored_macros) --output html \
+	prefacios/english_abstract.tex > report_en.html
 


### PR DESCRIPTION
Se había perdido este cambio en el Makefile para ejecutar los comandos del corrector ortográfico, por eso en los otros PR no me mostraba bien los fallos ortográficos. Closes #20 closes #29 . Estas issues se cierran ya que se ha implementado y funciona el corrector ortográfico correctamente
