### PR TITLE
Issue #46 , añadir las gemas rubocop y overcommit

### DIFF
--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,39 @@
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/sds/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/sds/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/sds/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+#PreCommit:
+#  RuboCop:
+#    enabled: true
+#    on_warn: fail # Treat all warnings as failures
+#
+#  TrailingWhitespace:
+#    enabled: true
+#    exclude:
+#      - '**/db/structure.sql' # Ignore trailing whitespace in generated files
+#
+#PostCheckout:
+#  ALL: # Special hook name that customizes all hooks of this type
+#    quiet: true # Change all post-checkout hooks to only display output on failure
+#
+#  IndexTags:
+#    enabled: true # Generate a tags file with `ctags` each time HEAD changes
+
+PreCommit:
+ RuboCop:
+   enabled: true
+   on_warn: fail # Treat all warnings as failures
+   problem_on_unmodified_line: ignore # run RuboCop only on modified code

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,9 @@
+
+Style/Encoding:
+  Enabled: false
+
+Layout/LineLength:
+  Max: 99
+
+Style/FrozenStringLiteralComment:
+  Enabled: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM ruby:3.0.2
+
+RUN apt-get update && apt-get install -y nano
+
+RUN mkdir TFG-Triage-Inteligente-Consulta-Medica
+
+WORKDIR /TFG-Triage-Inteligente-Consulta-Medica
+
+COPY . /TFG-Triage-Inteligente-Consulta-Medica
+
+RUN gem install bundler
+
+RUN bundler install
+
+
+

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }
+
+gem 'rubocop', '~> 1.54', require: false
+
+group :development, :test do
+  # run rubocop before commit with overcommit and much more
+  gem 'overcommit', '~> 0.58.0'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,37 @@
+GEM
+  specs:
+    ast (2.4.2)
+    json (2.5.1)
+    language_server-protocol (3.17.0.3)
+    parallel (1.23.0)
+    parser (3.2.2.3)
+      ast (~> 2.4.1)
+      racc
+    racc (1.5.1)
+    rainbow (3.1.1)
+    regexp_parser (2.8.1)
+    rexml (3.2.5)
+    rubocop (1.54.2)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.2.2.3)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.28.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.29.0)
+      parser (>= 3.2.1.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (2.4.2)
+
+PLATFORMS
+  x86_64-linux
+
+DEPENDENCIES
+  rubocop (~> 1.54)
+
+BUNDLED WITH
+   2.4.17

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.1'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - .:/TFG-Triage-Inteligente-Consulta-Medica
+


### PR DESCRIPTION
En este PR he añadido la configuración para poder usar el linter y ejecutarlo antes de cada commit. Además lo he hecho utilizando docker para utilizar un contenedor a parte del local y no cargar mi ordenador de mucho trabajo. 
Este PR es necesario para comprobar antes de cada commit que el código es limpio y correcto. 
Se aceptará cuando se ejecute el rubocop antes de cada commit
ESTE PULL REQUEST ESTÁ OBSOLETO. Debido a las última decisiones tomadas este PR no se mergeará